### PR TITLE
Fixed a bug that causes the application to remain running

### DIFF
--- a/GenesisDex/FormMain.Designer.cs
+++ b/GenesisDex/FormMain.Designer.cs
@@ -324,6 +324,7 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "PokeGenesis";
             this.TransparencyKey = System.Drawing.Color.FromArgb(((int)(((byte)(64)))), ((int)(((byte)(0)))), ((int)(((byte)(64)))));
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.FormMain_FormClosed);
             this.MouseDown += new System.Windows.Forms.MouseEventHandler(this.FormMain_MouseDown);
             this.MouseMove += new System.Windows.Forms.MouseEventHandler(this.FormMain_MouseMove);
             this.MouseUp += new System.Windows.Forms.MouseEventHandler(this.FormMain_MouseUp);

--- a/GenesisDex/FormMain.cs
+++ b/GenesisDex/FormMain.cs
@@ -994,5 +994,10 @@ namespace GenesisDex
         {
             btnMinimize.Image = getImage(AppDomain.CurrentDomain.BaseDirectory + "Data\\GUI\\MinimizeButton.png");
         }
+
+        private void FormMain_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            Application.Exit();
+        }
     }
 }


### PR DESCRIPTION
The application can remain running in the background if the application is closed from the windows task bar, This fix solves this issue by calling the `Application.Exit()` function when the `form.FormClosed` event is invoked